### PR TITLE
Allow args in dapp test

### DIFF
--- a/libexec/dapp/dapp-test
+++ b/libexec/dapp/dapp-test
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 dapp build
-dapp quicktest "$DAPP_OUT" $@
+dapp quicktest "$DAPP_OUT" "$@"

--- a/libexec/dapp/dapp-test
+++ b/libexec/dapp/dapp-test
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 dapp build
-dapp quicktest "$DAPP_OUT"
+dapp quicktest "$DAPP_OUT" $@


### PR DESCRIPTION
This lets you send arguments to `dapp quicktest` (like `-v`)