### PR TITLE
Sub select tests with regex

### DIFF
--- a/libexec/dapp/dapp-quicktest
+++ b/libexec/dapp/dapp-quicktest
@@ -35,6 +35,15 @@ for (var i = 0; i < PROGRAM_ARGS.length; i++) {
     skipBuild = true
   } else if (/^(-v|--(verbose|report))$/.test(arg)) {
     verbose++
+  } else if (/^(-r|--regex)$/.test(arg)) {
+    next = PROGRAM_ARGS[i + 1]
+    if (next !== undefined && !/^-/.test(next)) {
+      testRegex = new RegExp(next)
+      i++
+    } else {
+      console.error(`${PROGRAM_NAME}: ${arg} requires an argument`)
+      process.exit(1)
+    }
   } else if (/^-/.test(arg)) {
     console.error(`${PROGRAM_NAME}: unknown option: ${arg}`)
     process.exit(1)

--- a/libexec/dapp/dapp-quicktest
+++ b/libexec/dapp/dapp-quicktest
@@ -27,6 +27,7 @@ process.on("unhandledException", () => process.exit(1))
 var inputFiles = []
 var skipBuild = false
 var verbose = 0
+var testRegex = new RegExp('^test')
 
 for (var i = 0; i < PROGRAM_ARGS.length; i++) {
   var arg = PROGRAM_ARGS[i]
@@ -394,7 +395,7 @@ function getTestMethods() {
 }
 
 function isTestMethod({ name, inputs }) {
-  return /^test/.test(name) && inputs.length == 0
+  return testRegex.test(name) && inputs.length == 0
 }
 
 function sortMembers(members) {


### PR DESCRIPTION
`dapp -r '^testMyRegex'` will only run tests with names matching `^testMyRegex`.

`dapp -r 'Foo'` will run tests with `Foo` in the name somewhere.                                                                                                                                     

Possible things to add:                                                                                                                                                                                              
- ~~case insensitivity when no uppercase given~~                                                                                                                                                                         
- match anywhere in the name if plain string given (i.e. default `.*MyFragment.*`) 

~~Also introduces `minimist` as an arg parser for `dapp test`.~~