### PR TITLE
solc --overwrite

### DIFF
--- a/libexec/dapp/dapp-build
+++ b/libexec/dapp/dapp-build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e -o pipefail && shopt -s nullglob
-solc=(solc $SOLC_FLAGS --abi --bin --bin-runtime = -o "$DAPP_OUT")
+solc=(solc $SOLC_FLAGS --abi --bin --bin-runtime = -o "$DAPP_OUT" --overwrite)
 remappings=$(dapp remappings)
 while read -r line; do solc+=("$line"); done <<<"$remappings"
 for x in $DAPP_SRC/*.sol; do (set -x; "${solc[@]}" "$x"); done


### PR DESCRIPTION
Without it I was unable to compile more than one *.sol file in `src` in `sai`.

Also, only the first compilation attempt succeeded as for subsequent ones `solc` used to complain about  'Refusing to overwrite existing file' and quit.