### PR TITLE
Add Solc requirement in your README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 ## Installation
 
+Please make sure you have [`solc` installed in your CLI](https://solidity.readthedocs.io/en/develop/installing-solidity.html)
 ```
    make link                  install dapp(1) into /usr/local
    make uninstall             uninstall dapp(1) from /usr/local


### PR DESCRIPTION
Notify a developer that he has to have a `solc` installed globally.