### PR TITLE
Change to fix error message by shellcheck version: 0.4.6

### DIFF
--- a/libexec/dapp/dapp-init
+++ b/libexec/dapp/dapp-init
@@ -24,7 +24,7 @@ insert .gitignore <<.
 .
 
 name=$(basename "$(pwd)")
-name=$(<<<"$name" tr A-Z a-z)
+name=$(<<<"$name" tr '[:upper:]' '[:lower:]')
 nouns=(${name//[^a-z]/ })
 noun=${nouns[$((${#nouns[@]} - 1))]}
 type=$(<<<"$name" perl -pe 's/(\w+)/\u$1/g')


### PR DESCRIPTION
I got the following error message, when doing make:
```
cut -d: -f1 | xargs shellcheck

In libexec/dapp/dapp-init line 27:
name=$(<<<"$name" tr A-Z a-z)
                     ^-- SC2019: Use '[:upper:]' to support accents and foreign alphabets.
                         ^-- SC2018: Use '[:lower:]' to support accents and foreign alphabets.

make: *** [Makefile:15: test] Error 123
```
This fixes the error.
ShellCheck - shell script analysis tool
version: 0.4.6