### PR TITLE
dapp-build: add --optimize flag

### DIFF
--- a/libexec/dapp/dapp-build
+++ b/libexec/dapp/dapp-build
@@ -5,6 +5,7 @@ set -e
 opts=($SOLC_FLAGS)
 json_opts=--combined-json=abi,bin,bin-runtime,srcmap,srcmap-runtime
 solc --help | grep -q -- --overwrite && opts+=(--overwrite)
+solc --help | grep -q -- --optimize && opts+=(--optimize)
 
 remappings=$(dapp remappings)
 if [[ $remappings ]]; then


### PR DESCRIPTION
Adding the `--optimize` flag is solc support it.
The use of such flag can highly reduce the gas usage of a contract, at deployment time as well as at usage time. Such difference can be seen by using the `--gas` flag.