### PR TITLE
change file listing method

### DIFF
--- a/libexec/dapp/dapp-build
+++ b/libexec/dapp/dapp-build
@@ -14,6 +14,7 @@ fi
 shopt -s nullglob
 find "${DAPP_SRC}" -name "*.sol" | while read -r x; do
   (set -x; solc "${opts[@]}" --abi --bin --bin-runtime = -o "$DAPP_OUT" "$x")
-  json_file=$DAPP_OUT/${x#$DAPP_SRC}.json
+  tmp=${x##*/}
+  json_file=$DAPP_OUT/${tmp#DAPP_SRC}.json
   (set -x; solc "${opts[@]}" "${json_opts[@]}" = "$x" >"$json_file")
 done

--- a/libexec/dapp/dapp-build
+++ b/libexec/dapp/dapp-build
@@ -12,7 +12,7 @@ if [[ $remappings ]]; then
 fi
 
 shopt -s nullglob
-for x in `find '${DAPP_SRC}' -name '*.sol'`; do
+for x in `find ${DAPP_SRC} -name '*.sol'`; do
   (set -x; solc "${opts[@]}" --abi --bin --bin-runtime = -o "$DAPP_OUT" "$x")
   json_file=$DAPP_OUT/${x#$DAPP_SRC}.json
   (set -x; solc "${opts[@]}" "${json_opts[@]}" = "$x" >"$json_file")

--- a/libexec/dapp/dapp-build
+++ b/libexec/dapp/dapp-build
@@ -12,7 +12,7 @@ if [[ $remappings ]]; then
 fi
 
 shopt -s nullglob
-for x in "${DAPP_SRC}"/*.sol; do
+for x in `find '${DAPP_SRC}' -name '*.sol'`; do
   (set -x; solc "${opts[@]}" --abi --bin --bin-runtime = -o "$DAPP_OUT" "$x")
   json_file=$DAPP_OUT/${x#$DAPP_SRC}.json
   (set -x; solc "${opts[@]}" "${json_opts[@]}" = "$x" >"$json_file")

--- a/libexec/dapp/dapp-build
+++ b/libexec/dapp/dapp-build
@@ -12,7 +12,7 @@ if [[ $remappings ]]; then
 fi
 
 shopt -s nullglob
-for x in `find ${DAPP_SRC} -name '*.sol'`; do
+find "${DAPP_SRC}" -name "*.sol" | while read x; do
   (set -x; solc "${opts[@]}" --abi --bin --bin-runtime = -o "$DAPP_OUT" "$x")
   json_file=$DAPP_OUT/${x#$DAPP_SRC}.json
   (set -x; solc "${opts[@]}" "${json_opts[@]}" = "$x" >"$json_file")

--- a/libexec/dapp/dapp-build
+++ b/libexec/dapp/dapp-build
@@ -12,7 +12,7 @@ if [[ $remappings ]]; then
 fi
 
 shopt -s nullglob
-find "${DAPP_SRC}" -name "*.sol" | while read x; do
+find "${DAPP_SRC}" -name "*.sol" | while read -r x; do
   (set -x; solc "${opts[@]}" --abi --bin --bin-runtime = -o "$DAPP_OUT" "$x")
   json_file=$DAPP_OUT/${x#$DAPP_SRC}.json
   (set -x; solc "${opts[@]}" "${json_opts[@]}" = "$x" >"$json_file")


### PR DESCRIPTION
Patch the `dapp build` command so dapp can now build files which are not at the root of `./src`.