### PR TITLE
Prototype of Nix integration and solc picking

### DIFF
--- a/libexec/dapp/dapp
+++ b/libexec/dapp/dapp
@@ -4,6 +4,28 @@ export DAPP_SRC=${DAPP_SRC-src}
 export DAPP_LIB=${DAPP_LIB-lib}
 export DAPP_OUT=${DAPP_OUT-out}
 
+function have() { command -v "$1" >/dev/null 2>&1 ; }
+
+for dep in bc curl git node solc ethabi ethrun seth jshon; do
+  if ! have $dep; then missing+=($dep); fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo >&2 "${0##*/}: missing dependencies"
+  echo >&2
+  cat <<-EOF
+If you want to install missing dependencies by hand,
+then answer no to the following and install the following:
+
+    ${missing[@]}
+
+But we recommend that you let Dapp manage its own tools,
+and answer yes to the following.
+EOF
+
+  exec "${0##*/}-nix-setup"
+fi
+
 version=$(solc --version)
 if grep -q 0.4.9 <<<"$version"; then
   echo >&2 "${0##*/}: error: solc 0.4.9 not supported"

--- a/libexec/dapp/dapp---use
+++ b/libexec/dapp/dapp---use
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+function usage() {
+  echo >&2 "Usage: dapp --use <spec> <subcommand>..."
+  echo >&2 "Example:"
+  echo >&2
+  echo >&2 "  $ dapp --use solc:0.4.11 test"
+  echo >&2
+  exit 1
+}
+
+[[ "$#" > 0 ]] || usage
+
+function have() { command -v "$1" >/dev/null 2>&1 ; }
+if ! have nix-shell; then exec dapp nix-setup; fi
+
+export NIX_PATH=dapphub=$HOME/.nix-defexpr/channels/dapphub:$NIX_PATH
+BINARY_CACHE=$(cat ~/.nix-defexpr/channels/binary-caches/dapphub)
+
+shopt -s extglob
+case $1 in
+  solc:[0-9].+([0-9.]))
+    version=${1#solc:}
+    version=${version//./_}
+    override+=" solc = solc-versions.solc_$version;"
+    ;;
+  *)
+    echo >&2 "${0##*/}: unrecognized package spec: $1"
+    exit 1
+esac
+shift
+
+[[ "$#" > 0 ]] || usage
+
+nix-shell \
+ --option binary-caches "$BINARY_CACHE" \
+  -p "with import <dapphub> {}; dapp.override {$override }" \
+  --run "dapp $*"

--- a/libexec/dapp/dapp-nix-setup
+++ b/libexec/dapp/dapp-nix-setup
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -e
+
+function verify() {
+  read -e -p "$1 [y/n] " answer
+  [[ $answer == y ]] || [[ $answer == yes ]]
+}
+
+if ! command -v nix-env >/dev/null 2>&1; then
+  echo >&2 
+ cat >&2 <<"EOF"
+Dapp uses the Nix package manager to manage external tools.
+
+Nix is a very useful meta-tool.  All of its tools will be
+self-contained in the /nix directory in a robust way.
+
+We can launch the automatic Nix installer that works on both Linux and
+OS X.
+
+If you want to educate yourself first, please visit the Nix website
+and become convinced of its wholesome and beneficial nature.
+
+                   https://nixos.org/nix
+
+EOF
+  if verify "Install Nix?"; then
+    if ! command -v curl >/dev/null 2>&1; then
+      echo >&2
+      echo >&2 "Error: please first install curl."
+      exit 1
+    fi
+    if ! command -v bzcat >/dev/null 2>&1; then
+      echo >&2
+      echo >&2 "Error: please first install bzip2."
+      exit 1
+    fi
+    
+    echo >&2
+    curl https://nixos.org/nix/install | bash
+
+    echo >&2 "${0##*/}: Congratulations -- Nix is installed."
+    if verify "Setup shell profile?"; then
+      ( set +x
+        echo ". ~/.nix-profile/etc/profile.d/nix.sh" >> ~/.profile
+      )
+    fi
+
+    . ~/.nix-profile/etc/profile.d/nix.sh
+
+    echo >&2 "${0##*/}: Configuring the DappHub channel..."
+    nix-channel --add https://nix.dapphub.com/pkgs/dapphub
+    nix-channel --update
+    
+    echo >&2 "${0##*/}: Installing dapp via Nix..."
+    nix-env -iA dapphub.dapp
+
+    echo >&2 "${0##*/}: Excellent!  Log out or run the following:"
+    echo >&2
+    echo >&2 "    source ~/.nix-profile/etc/profile.d/nix.sh"
+    echo >&2
+    echo >&2 "and you will be fully set up to develop dapps."
+  fi
+fi


### PR DESCRIPTION
This pretty much works fine! But we shouldn't merge it immediately, 
there's some stuff to consider and some stuff to do.

See #53. cc @dbrock 

I can run dapp in a clean Ubuntu Docker, and it will commence installing
Nix, setting up the DappHub Nix channel, and then reinstalling dapp
via Nix.

It's kind of weird though that you would first download the dapp source
code and install it, and then it would immediately reinstall itself in a
different place using Nix.

So I'm not sure, maybe there should be a separate easy install script,
instead of the check in the main dapp program.

Until this dapp version is actually in Nix, the `dapp --use` won't work.