### PR TITLE
Add `bc` to Dockerfile installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:7.10.0
 
 RUN apt-get update && \
-    apt-get install -y sudo git wget curl make && \
+    apt-get install -y sudo git wget curl make bc && \
 	git clone https://github.com/dapphub/seth && \
 	git clone https://github.com/dapphub/dapp && \
 	make link -C seth && \


### PR DESCRIPTION
Some `seth` methods like `to-wei` depend on `bc`.

**Before**
```bash
node@c693e002dd7b:/src$ seth --to-wei 1 gwei
/usr/local/libexec/seth/seth---to-wei: line 18: bc: command not found
```

**After**
```bash
node@c693e002dd7b:/src$ seth --to-wei 1 gwei
1000000000
```