### PR TITLE
Add switch to turn off pre-test building

### DIFF
--- a/libexec/dapp/dapp-test
+++ b/libexec/dapp/dapp-test
@@ -2,7 +2,7 @@
 set -e
 have() { command -v "$1" >/dev/null; }
 
-if ! [[ $DAPP_NO_PRETEST_BUILD ]] ; then
+if ! [[ $DAPP_SKIP_BUILD ]] ; then
   DAPP_LINK_TEST_LIBRARIES=1 dapp build || exit
 fi
 

--- a/libexec/dapp/dapp-test
+++ b/libexec/dapp/dapp-test
@@ -2,7 +2,9 @@
 set -e
 have() { command -v "$1" >/dev/null; }
 
-DAPP_LINK_TEST_LIBRARIES=1 dapp build || exit
+if ! [[ $DAPP_NO_PRETEST_BUILD ]] ; then
+  DAPP_LINK_TEST_LIBRARIES=1 dapp build || exit
+fi
 
 have hevm   && ! [[ $DAPP_NO_HEVM   ]] && dapp test-hevm   "$@"
 have ethrun && ! [[ $DAPP_NO_ETHRUN ]] && dapp test-ethrun "$@"


### PR DESCRIPTION
Using dapp on a larger project and we run some js tests on our code, so we already have a `dapp build` compilation step.
Running the compiler again when doing our `ds-test` tests should not be necessary, right? Just seems to make our builds a little longer.
If this is not a good idea, call me out