### PR TITLE
dapp testnet takes an optional number of seconds to simulate mining

### DIFF
--- a/libexec/dapp/dapp---testnet-launch
+++ b/libexec/dapp/dapp---testnet-launch
@@ -33,6 +33,6 @@ echo "$port"                     > "$chaindir/config/node-port"
 
 geth \
   2> >(tee "$chaindir/geth.log" | grep --line-buffered Success | sed 's/^/geth: /' >&2) \
-  --datadir "$chaindir" --dev --networkid "$chainid" --port="$port" \
+  --datadir "$chaindir" --dev --dev.period "$DAPP_PERIOD" --networkid "$chainid" --port="$port" \
   --rpc --rpcapi "web3,eth,debug" --rpccorsdomain '*' --nodiscover \
   --rpcport="$chainid" --unlock="$address" --password=<(exit)

--- a/libexec/dapp/dapp---testnet-launch
+++ b/libexec/dapp/dapp---testnet-launch
@@ -33,6 +33,6 @@ echo "$port"                     > "$chaindir/config/node-port"
 
 geth \
   2> >(tee "$chaindir/geth.log" | grep --line-buffered Success | sed 's/^/geth: /' >&2) \
-  --datadir "$chaindir" --dev --dev.period "$DAPP_PERIOD" --networkid "$chainid" --port="$port" \
+  --datadir "$chaindir" --dev --dev.period "$DAPP_TESTNET_BLOCK_TIME" --networkid "$chainid" --port="$port" \
   --rpc --rpcapi "web3,eth,debug" --rpccorsdomain '*' --nodiscover \
   --rpcport="$chainid" --unlock="$address" --password=<(exit)

--- a/libexec/dapp/dapp-testnet
+++ b/libexec/dapp/dapp-testnet
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+export DAPP_PERIOD="${1:-0}"
 dapp --nix-run go-ethereum-unlimited dapp --testnet-launch

--- a/libexec/dapp/dapp-testnet
+++ b/libexec/dapp/dapp-testnet
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-export DAPP_PERIOD="${1:-0}"
+export DAPP_TESTNET_BLOCK_TIME="${1:-0}"
 dapp --nix-run go-ethereum-unlimited dapp --testnet-launch


### PR DESCRIPTION
Very useful for simulating transactions taking a long time to be mined.

`dapp testnet 60` will mine a block every 60 seconds.

`dapp testnet` sets the period to 0, enabling mining whenever a transaction is pending (what was already happening)