### PR TITLE
Handle solc develop versions correctly

### DIFF
--- a/libexec/dapp/dapp-init
+++ b/libexec/dapp/dapp-init
@@ -5,7 +5,7 @@ set -e -o noclobber
 solc_version=$(solc --version)
 solc_version=$(<<<"$solc_version" grep ^Version:)
 solc_version=${solc_version#* }
-solc_version=${solc_version%%+*}
+solc_version=${solc_version%%[+-]*}
 
 create() { [[ -e $1 ]] || { cat >"$1"; (set -x; git add "$1"); }; }
 insert() {


### PR DESCRIPTION
This should fix the generated sources when the version string looks like this:
```
Version: 0.4.20-develop.2018.1.6+commit.efba4250.Darwin.appleclang
```
