### PR TITLE
Create .gitattributes on dapp-init

### DIFF
--- a/libexec/dapp/dapp-init
+++ b/libexec/dapp/dapp-init
@@ -23,6 +23,10 @@ insert .gitignore <<.
 /out
 .
 
+create .gitattributes <<.
+*.sol linguist-language=Solidity
+.
+
 name=$(basename "$(pwd)")
 name=$(<<<"$name" tr '[:upper:]' '[:lower:]')
 nouns=(${name//[^a-z]/ })


### PR DESCRIPTION
With this .gitattributes file, it gives a hint to Github so it correctly highlights Solidity syntax on its webpage.