### PR TITLE
upgrade solc: 4.16 => 4.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 	mv ethrun /usr/local/bin/ethrun && \
 	chmod +x /usr/local/bin/ethrun && \
 	rm -rf ethrun-v0.2.4-linux.tar.gz && \
-	wget https://github.com/ethereum/solidity/releases/download/v0.4.16/solc-static-linux && \
+	wget https://github.com/ethereum/solidity/releases/download/v0.4.23/solc-static-linux && \
 	mv solc-static-linux /usr/local/bin/solc && \
 	chmod +x /usr/local/bin/solc && \
 	echo "node ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
Similar to https://github.com/dapphub/dapp/pull/50, this is a band-aid fix for solidity version being out of date. I would prefer if it instead used my installed version of `solc` when available.